### PR TITLE
Add activity feed API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Draftflow is a collaborative AI editor. You type text, the AI acts like another participant in a Google Doc and goes and corrects your writing for you.
 
-See [this post]([url](https://vishnugopal.com/2025/02/04/draftflow-a-collaborative-crdt-aware-editor-ai/)) for more info.
+See [this post]((https://vishnugopal.com/2025/02/04/draftflow-a-collaborative-crdt-aware-editor-ai/)) for more info.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Draftflow is a collaborative AI editor. You type text, the AI acts like another participant in a Google Doc and goes and corrects your writing for you.
 
+See [this post]([url](https://vishnugopal.com/2025/02/04/draftflow-a-collaborative-crdt-aware-editor-ai/)) for more info.
+
 ## Getting Started
 
 First, make sure you have an `OPENAI_API_KEY=` line with [the API key](https://platform.openai.com/settings/organization/api-keys) in `.env.local`.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 Draftflow is a collaborative AI editor. You type text, the AI acts like another participant in a Google Doc and goes and corrects your writing for you.
 
-See [this post]((https://vishnugopal.com/2025/02/04/draftflow-a-collaborative-crdt-aware-editor-ai/)) for more info.
+
+
+See [this post](https://vishnugopal.com/2025/02/04/draftflow-a-collaborative-crdt-aware-editor-ai/) for more info.
 
 ## Getting Started
 

--- a/graphite-demo/server.js
+++ b/graphite-demo/server.js
@@ -1,0 +1,30 @@
+const express = require('express');
+const app = express();
+const port = 3000;
+
+// Fake data for the activity feed
+const activityFeed = [
+  {
+    id: 1000,
+    title: 'New Photo Uploaded',
+    body: 'Alice uploaded a new photo to her album.'
+  },
+  {
+    id: 2000,
+    title: 'Comment on Post',
+    body: "Bob commented on Charlie's post."
+  },
+  {
+    id: 13,
+    title: 'Status Update',
+    body: 'Charlie updated their status: "Excited about the new project!"'
+  }
+];
+
+app.get('/feed', (req, res) => {
+  res.json(activityFeed);
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,7 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
-    "server.js"
+    "src/server.js"
   ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
### TL;DR

Added a blog post link to README and created a demo server for activity feed.

### What changed?

- Added a link to a blog post about Draftflow in the README.md file
- Created a new Express server in `graphite-demo/server.js` that provides a mock activity feed API
- Updated the path to server.js in tsconfig.json from "server.js" to "src/server.js"

### How to test?

1. Check that the README displays the new blog post link correctly
2. Run the demo server with `node graphite-demo/server.js`
3. Access `http://localhost:3000/feed` to verify it returns the mock activity feed data

### Why make this change?

This change provides additional documentation for users through the blog post link and sets up a demo server that can be used for testing the activity feed functionality in the application.