### PR TITLE
Add server API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Draftflow is a collaborative AI editor. You type text, the AI acts like another participant in a Google Doc and goes and corrects your writing for you.
 
-See [this post]([url](https://vishnugopal.com/2025/02/04/draftflow-a-collaborative-crdt-aware-editor-ai/)) for more info.
+See [this post]((https://vishnugopal.com/2025/02/04/draftflow-a-collaborative-crdt-aware-editor-ai/)) for more info.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Draftflow is a collaborative AI editor. You type text, the AI acts like another participant in a Google Doc and goes and corrects your writing for you.
 
+See [this post]([url](https://vishnugopal.com/2025/02/04/draftflow-a-collaborative-crdt-aware-editor-ai/)) for more info.
+
 ## Getting Started
 
 First, make sure you have an `OPENAI_API_KEY=` line with [the API key](https://platform.openai.com/settings/organization/api-keys) in `.env.local`.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 Draftflow is a collaborative AI editor. You type text, the AI acts like another participant in a Google Doc and goes and corrects your writing for you.
 
-See [this post]((https://vishnugopal.com/2025/02/04/draftflow-a-collaborative-crdt-aware-editor-ai/)) for more info.
+
+
+See [this post](https://vishnugopal.com/2025/02/04/draftflow-a-collaborative-crdt-aware-editor-ai/) for more info.
 
 ## Getting Started
 

--- a/graphite-demo/server.js
+++ b/graphite-demo/server.js
@@ -1,0 +1,36 @@
+const express = require('express');
+const app = express();
+const port = 3000;
+
+// Fake data for tasks
+const tasks = [
+  {
+    id: 1,
+    description: 'Complete monthly financial report'
+  },
+  {
+    id: 2,
+    description: 'Plan team building activity'
+  },
+  {
+    id: 3,
+    description: 'Update project documentation'
+  }
+];
+
+app.get('/search', (req, res) => {
+  // Retrieve the query parameter
+  const query = req.query.query?.toLowerCase() || '';
+
+  // Filter tasks based on the query
+  const filteredTasks = tasks.filter(task => task.description.toLowerCase().includes(query));
+
+  // Sort the filtered tasks alphabetically by description
+  const sortedTasks = filteredTasks.sort((a, b) => a.description.localeCompare(b.description));
+
+  res.json(sortedTasks);
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,7 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
-    "server.js"
+    "src/server.js"
   ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
### TL;DR

Added a blog post link to README, created a new Express server for task searching, and updated the TypeScript configuration path.

### What changed?

- Added a link to a blog post about Draftflow in the README.md file
- Created a new Express server in `graphite-demo/server.js` that provides a `/search` endpoint for filtering tasks
- Updated the path in tsconfig.json from "server.js" to "src/server.js"

### How to test?

1. Check that the README contains the new blog post link
2. Run the Express server in the graphite-demo directory:
   ```
   cd graphite-demo
   node server.js
   ```
3. Test the search endpoint with:
   ```
   curl "http://localhost:3000/search?query=report"
   ```
   This should return the task about the financial report

### Why make this change?

- The blog post link provides additional context and information about the Draftflow project
- The new Express server in graphite-demo provides a simple task search API for demonstration purposes
- The tsconfig.json update ensures TypeScript correctly references the server file in its new location